### PR TITLE
Make pathPatterns property optional for proxy config

### DIFF
--- a/server.js
+++ b/server.js
@@ -131,9 +131,11 @@ conf.servers.forEach(function(serverConf) {
 			var simplePaths = [];
 			var pathRewrites = [];
 			var hostRegExp = proxy.hostPattern && new RegExp(proxy.hostPattern);
-			proxy.pathPatterns.forEach(function(path) {
-				(typeof path == 'string' ? simplePaths : pathRewrites).push(path);
-			});
+			if (proxy.pathPatterns) {
+				proxy.pathPatterns.forEach(function(path) {
+					(typeof path == 'string' ? simplePaths : pathRewrites).push(path);
+				});
+			}
 			if (simplePaths.length) {
 				app.use(getProxyCheckRequestHandler(new RegExp("(?:" + simplePaths.join(")|(?:") + ")"), proxy.target, hostRegExp));
 				messages += "\n" + featureStyle("Redirecting") + " path patterns: " + boldStyle(simplePaths.join(", ")) + " to "


### PR DESCRIPTION
When a proxy configuration doesn't contain `pathPatterns` property, `swb` exits with the following error on startup:
```
server.js:134
                        proxy.pathPatterns.forEach(function(path) {
                                           ^

TypeError: Cannot read property 'forEach' of undefined
```
The proposed change fixes that problem.